### PR TITLE
Made homepage more compact

### DIFF
--- a/src/IndexPage.tsx
+++ b/src/IndexPage.tsx
@@ -55,12 +55,6 @@ const App = () => <RedZap />
         <a href="https://github.com/styled-icons/styled-icons">View documentation on GitHub</a>
       </p>
 
-      <p>
-        <a href="https://vercel.com/?utm_source=styled-icons">
-          <img height="30" src="/powered-by-vercel.svg" alt="Powered by Vercel" />
-        </a>
-      </p>
-
       <h2>Icon Explorer</h2>
 
       <IconExplorer />

--- a/src/components/Badges.tsx
+++ b/src/components/Badges.tsx
@@ -15,5 +15,9 @@ export const Badges: React.SFC = () => (
       <img src="https://badgen.net/badge/built%20with/styled%20components/db7093" alt="Built with Styled Components" />
     </a>
     <img src="https://badgen.net/badge/powered%20by/typescript/blue" alt="Powered by TypeScript" />
+
+    <a href="https://vercel.com/?utm_source=styled-icons">
+      <img height="20" src="/powered-by-vercel.svg" alt="Powered by Vercel" />
+    </a>
   </div>
 )

--- a/src/components/IconExplorer.tsx
+++ b/src/components/IconExplorer.tsx
@@ -69,7 +69,7 @@ const IconExporer: React.SFC = () => {
         {({height, isScrolling, scrollTop}) => (
           <AutoSizer disableHeight>
             {({width}) => {
-              const columnCount = width > 755 ? 4 : width < 600 ? 2 : 3
+              const columnCount = width > 755 ? 3 : width < 600 ? 1 : 2
               const rowCount = Math.ceil(filteredIcons.length / columnCount)
               const size = Math.floor(width / columnCount)
 
@@ -82,7 +82,7 @@ const IconExporer: React.SFC = () => {
                   height={height}
                   isScrolling={isScrolling}
                   rowCount={rowCount}
-                  rowHeight={size}
+                  rowHeight={120}
                   scrollTop={scrollTop}
                   width={width}
                 />

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -64,13 +64,15 @@ const GlobalStyle = createGlobalStyle`
   .icon-card {
     background: rgba(0, 0, 0, 0.2);
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 10px;
     align-items: center;
-    justify-content: space-evenly;
+    justify-content: flex-start;
     padding: 1rem;
     cursor: pointer;
     color: #fff;
-    transition: transform 0.5s ease-out;
+    transition: transform 0.2s ease-out;
     will-change: transform;
     width: 100%;
     height: 100%;
@@ -83,12 +85,15 @@ const GlobalStyle = createGlobalStyle`
   .icon-card .name {
     font-weight: 500;
     overflow-x: scroll;
-    width: 100%;
+    flex-grow: 1;
+    text-align: left;
+    margin-left: 5px;
+    width: 0;  // Avoid it moving to the next line
   }
 
   .icon-card code {
     width: 100%;
-    text-align: center;
+    text-align: left;
     padding: 0;
   }
 


### PR DESCRIPTION
Made the cards smaller, and so IMHO I believe 3-column by default looks pretty good. Moved Vercel's badge to the badge area, so that the icons are shown by default above the fold.

<table>
  <tr><th>Before</th><th>After</th></tr>
  <tr>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/165399671-8f28d7b6-4b0b-4604-bdc1-035c991702dd.png" />
    </td>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/165399706-8643468d-6bac-45f0-9bd2-ee26b991a6a9.png" />
    </td>
  </tr>
  <tr>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/165399905-7162ea22-6b20-4640-b9d5-c9a0e8c802fb.png" />
    </td>
    <td>
      <img width="500px" src="https://user-images.githubusercontent.com/2801252/165400774-03c77a08-b193-4a92-996e-47520f9cad15.png" />
    </td>
  </tr>
</table>

Solves https://github.com/styled-icons/styled-icons/issues/2010